### PR TITLE
Pass primary key to functions supporting 'last/before'

### DIFF
--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -80,7 +80,7 @@ const nodesToReturn = async (
   }
   if (last) {
     if (last < 0) throw new Error('`last` argument must not be less than 0');
-    nodes = await removeNodesFromBeginning(nodesAccessor, last + 1, { orderColumn, ascOrDesc });
+    nodes = await removeNodesFromBeginning(nodesAccessor, last + 1, { orderColumn, ascOrDesc, primaryKey });
     if (nodes.length > last) {
       hasPreviousPage = true;
       nodes = nodes.slice(1);

--- a/src/orm-connectors/knex/custom-pagination.js
+++ b/src/orm-connectors/knex/custom-pagination.js
@@ -151,13 +151,13 @@ const removeNodesAfterAndIncluding = buildRemoveNodesFromBeforeOrAfter('after');
 // It must remove nodes from the result set starting from the beginning until it's of size `length`.
 // e.g. let [A, B, C, D] be the `resultSet`
 // removeNodesFromBeginning(resultSet, 3) should return [B, C, D]
-const removeNodesFromBeginning = (nodesAccessor, last, { orderColumn, ascOrDesc }) => {
+const removeNodesFromBeginning = (nodesAccessor, last, { orderColumn, ascOrDesc, primaryKey }) => {
   const invertedOrderArray = operateOverScalarOrArray([], ascOrDesc,
     (orderDirection, index, prev) => prev.concat(orderDirection === 'asc' ? 'desc' : 'asc'));
 
   const order = invertedOrderArray.length === 1 ? invertedOrderArray[0] : invertedOrderArray;
 
-  const subquery = orderNodesBy(nodesAccessor.clone().clearOrder(), { orderColumn, ascOrDesc: order }).limit(last);
+  const subquery = orderNodesBy(nodesAccessor.clone().clearOrder(), { orderColumn, ascOrDesc: order, primaryKey: primaryKey }).limit(last);
   const result = nodesAccessor.clone().from(subquery.as('last_subquery')).clearSelect().clearWhere();
   return result;
 };


### PR DESCRIPTION
Add primary key to methods that support 'before/last' pagination.

Confirmed that this change did not break the original tests. Attempted to add more tests for this behavior, but decided to opt for testing on downstream repo for now.

@bassrock can you please release this once it is merged, so I can confirm the fix in our repo? I am fairly sure that I transferred all the lines, but the linter makes the files look a little different in the node_modules distribution vs. the repo :)

